### PR TITLE
Plugin cli options

### DIFF
--- a/bin/repomate
+++ b/bin/repomate
@@ -1,6 +1,7 @@
 #! /usr/bin/env python3.6
 
+import sys
 from repomate import main
 
 if __name__ == "__main__":
-    main.main()
+    main.main(sys.argv)

--- a/repomate/cli.py
+++ b/repomate/cli.py
@@ -55,9 +55,16 @@ OPEN_ISSUE_PARSER = 'open-issue'
 CLOSE_ISSUE_PARSER = 'close-issue'
 VERIFY_PARSER = 'verify-settings'
 
-PARSER_NAMES = (SETUP_PARSER, UPDATE_PARSER, CLONE_PARSER, MIGRATE_PARSER,
-                ADD_TO_TEAMS_PARSER, OPEN_ISSUE_PARSER, CLONE_PARSER,
-                VERIFY_PARSER,)
+PARSER_NAMES = (
+    SETUP_PARSER,
+    UPDATE_PARSER,
+    CLONE_PARSER,
+    MIGRATE_PARSER,
+    ADD_TO_TEAMS_PARSER,
+    OPEN_ISSUE_PARSER,
+    CLONE_PARSER,
+    VERIFY_PARSER,
+)
 
 
 def parse_args(sys_args: Iterable[str]
@@ -502,13 +509,12 @@ def parse_plugins(sys_args: Tuple[str]):
     mutex_grp = parser.add_mutually_exclusive_group(required=True)
     mutex_grp.add_argument(
         '-p',
-        '--plugins',
-        help="One or more plugin names.",
+        '--plug',
+        help="Specify the name of a plugin to use.",
         type=str,
-        nargs='+',
+        action='append',
     )
     mutex_grp.add_argument(
-        '-np',
         '--no-plugins',
         help="Disable plugins.",
         action='store_true',

--- a/repomate/main.py
+++ b/repomate/main.py
@@ -9,20 +9,19 @@
 import sys
 import itertools
 import daiquiri
+from typing import List
 
 from repomate import cli
-from repomate import exception
 from repomate import plugin
 
 LOGGER = daiquiri.getLogger(__file__)
 
 
-# if the OAUTH token is not set, OSError is raised
-def main():
+def main(sys_args: List[str]):
     """Start the repomate CLI."""
-    args = sys.argv[1:]
+    args = sys_args[1:]  # drop the name of the program
     try:
-        if args and 'plugins' in args[0]:
+        if args and (args[0].startswith('-p') or 'plugin' in args[0]):
             plugin_args = list(
                 itertools.takewhile(lambda arg: arg not in cli.PARSER_NAMES,
                                     args))
@@ -30,7 +29,7 @@ def main():
             if parsed_plugin_args.no_plugins:
                 LOGGER.info("plugins disabled")
             else:
-                plugin.initialize_plugins(parsed_plugin_args.plugins)
+                plugin.initialize_plugins(parsed_plugin_args.plug)
             args = args[len(plugin_args):]
         else:
             plugin.initialize_plugins()
@@ -41,4 +40,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()
+    main(sys.argv)

--- a/repomate/main.py
+++ b/repomate/main.py
@@ -7,6 +7,7 @@
 """
 
 import sys
+import itertools
 import daiquiri
 
 from repomate import cli
@@ -19,9 +20,21 @@ LOGGER = daiquiri.getLogger(__file__)
 # if the OAUTH token is not set, OSError is raised
 def main():
     """Start the repomate CLI."""
+    args = sys.argv[1:]
     try:
-        plugin.initialize_plugins()
-        parsed_args, api = cli.parse_args(sys.argv[1:])
+        if args and 'plugins' in args[0]:
+            plugin_args = list(
+                itertools.takewhile(lambda arg: arg not in cli.PARSER_NAMES,
+                                    args))
+            parsed_plugin_args = cli.parse_plugins(plugin_args)
+            if parsed_plugin_args.no_plugins:
+                LOGGER.info("plugins disabled")
+            else:
+                plugin.initialize_plugins(parsed_plugin_args.plugins)
+            args = args[len(plugin_args):]
+        else:
+            plugin.initialize_plugins()
+        parsed_args, api = cli.parse_args(args)
         cli.dispatch_command(parsed_args, api)
     except Exception as exc:
         LOGGER.error("{.__class__.__name__}: {}".format(exc, str(exc)))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -588,6 +588,8 @@ class TestCloneParser:
 
     STUDENTS_STRING = ' '.join(STUDENTS)
 
+    #def test_no_plugins_option_drops_plugins()
+
     @pytest.mark.parametrize(
         'parser, extra_args',
         [
@@ -599,7 +601,8 @@ class TestCloneParser:
              ['-s', STUDENTS_STRING, '-mn', *REPO_NAMES, '-i', ISSUE_PATH]),
             (cli.CLOSE_ISSUE_PARSER,
              ['-s', STUDENTS_STRING, '-mn', *REPO_NAMES, '-r', 'some-regex']),
-            (cli.ADD_TO_TEAMS_PARSER, ['-s', STUDENTS_STRING]), # TODO fix add-to-teams or remove
+            (cli.ADD_TO_TEAMS_PARSER, ['-s', STUDENTS_STRING
+                                       ]),  # TODO fix add-to-teams or remove
             (cli.VERIFY_PARSER, ['-u', USER]),
             (cli.MIGRATE_PARSER, ['-u', USER, '-mn', *REPO_NAMES]),
         ])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, MagicMock
 import builtins
 import pytest
+from collections import namedtuple
 
 from pytest.functions import raise_
 import repomate
@@ -24,17 +25,20 @@ VALID_PARSED_ARGS = dict(
 
 PARSED_ARGS = tuples.Args(cli.SETUP_PARSER, **VALID_PARSED_ARGS)
 
-
-@pytest.fixture
-def monkeypatch_sys_args(monkeypatch):
-    sys_args = ['just some made up arguments'.split()]
-    monkeypatch.setattr('sys.argv', sys_args)
-    return sys_args
+module = namedtuple('module', ('name', ))
 
 
 @pytest.fixture
 def api_instance_mock(mocker):
     return MagicMock(spec='repomate.APIWrapper')
+
+
+@pytest.fixture
+def init_plugins_mock(mocker):
+    return mocker.patch(
+        'repomate.plugin.initialize_plugins',
+        autospec=True,
+        side_effect=lambda plugs: list(map(module, plugs)))
 
 
 @pytest.fixture
@@ -46,37 +50,73 @@ def parse_args_mock(mocker, api_instance_mock):
 
 
 @pytest.fixture
+def parse_plugins_mock(mocker):
+    return mocker.patch(
+        'repomate.cli.parse_plugins',
+        autospec=True,
+        side_effect=
+        lambda args: [arg for arg in args if not arg.startswith('-')])
+
+
+@pytest.fixture
 def dispatch_command_mock(mocker):
     return mocker.patch('repomate.cli.dispatch_command', autospec=True)
 
 
-def test_happy_path(monkeypatch_sys_args, api_instance_mock, parse_args_mock,
-                    dispatch_command_mock, no_config_mock):
-    main.main()
+def test_happy_path(api_instance_mock, parse_args_mock, dispatch_command_mock,
+                    no_config_mock):
 
-    parse_args_mock.assert_called_once_with(monkeypatch_sys_args[1:])
+    sys_args = ['just some made up arguments'.split()]
+
+    main.main(sys_args)
+
+    parse_args_mock.assert_called_once_with(sys_args[1:])
     dispatch_command_mock.assert_called_once_with(PARSED_ARGS,
                                                   api_instance_mock)
 
 
 def test_does_not_raise_on_exception_in_parsing(
-        monkeypatch_sys_args, api_instance_mock, parse_args_mock,
-        dispatch_command_mock, no_config_mock):
+        api_instance_mock, parse_args_mock, dispatch_command_mock,
+        no_config_mock):
     """should just log, but not raise."""
     msg = "some nice error message"
     parse_args_mock.side_effect = raise_(Exception(msg))
+    sys_args = ['just some made up arguments'.split()]
 
-    main.main()
+    main.main(sys_args)
 
-    parse_args_mock.assert_called_once_with(monkeypatch_sys_args[1:])
+    parse_args_mock.assert_called_once_with(sys_args[1:])
     assert not dispatch_command_mock.called
 
 
 def test_does_not_raise_on_exception_in_handling_parsed_args(
-        monkeypatch_sys_args, api_instance_mock, parse_args_mock,
-        dispatch_command_mock):
+        api_instance_mock, parse_args_mock, dispatch_command_mock):
     """should just log, but not raise."""
     msg = "some nice error message"
     dispatch_command_mock.side_effect = raise_(Exception(msg))
+    sys_args = ['just some made up arguments'.split()]
 
-    main.main()
+    main.main(sys_args)
+
+
+def test_plugins_args(parse_args_mock, dispatch_command_mock,
+                      init_plugins_mock):
+    plugin_args = '-p javac -p pylint'.split()
+    clone_args = 'clone -mn week-2 -s slarse'.split()
+    sys_args = ['repomate', *plugin_args, *clone_args]
+
+    main.main(sys_args)
+
+    init_plugins_mock.assert_called_once_with(['javac', 'pylint'])
+    parse_args_mock.assert_called_once_with(clone_args)
+
+
+def test_no_plugins_arg(parse_args_mock, dispatch_command_mock,
+                        init_plugins_mock):
+    clone_args = 'clone -mn week-2 -s slarse'.split()
+    sys_args = ['repomate', '--no-plugins', *clone_args]
+
+    main.main(sys_args)
+
+    assert not init_plugins_mock.called
+    parse_args_mock.assert_called_once_with(clone_args)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -34,6 +34,25 @@ class TestLoadPluginModules:
 
         assert module_names == expected_names
 
+    def test_plugin_names_override_config_file(self, config_mock, mocker):
+        """Test that the plugin_names argument override the configuration
+        file."""
+        plugin_names = ["awesome", "the_slarse_plugin", "ric_easter_egg"]
+        expected_calls = [
+            call(plug) for plug in map(plugin.PLUGIN_QUALNAME, plugin_names)
+        ]
+
+        class module:
+            pass
+
+        load_module_mock = mocker.patch(
+            'repomate.plugin._try_load_module', return_value=module)
+
+        plugin.load_plugin_modules(
+            config_file=str(config_mock), plugin_names=plugin_names)
+
+        load_module_mock.assert_has_calls(expected_calls)
+
     def test_load_no_plugins(self, no_config_mock):
         """Test calling load plugins when no plugins are specified in the
         config.
@@ -112,10 +131,6 @@ class TestRegisterPlugins:
             call(javac),
             call(javac_clone_hook_mock),
         ]
-
-        print(javac.JavacCloneHook())
-        print(javac_clone_hook_mock)
-
         plugin.register_plugins([javac, pylint])
 
         plugin_manager_mock.register.assert_has_calls(expected_calls)


### PR DESCRIPTION
Adds `--p|--plug` option for specifying plugins to use (overrides defaults).

Adds `-np|--no-plugins` option for completely disabling plugins.