### PR TITLE
Remove pluggy as a requirement in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,14 +18,7 @@ test_requirements = [
     "pytest-mock",
     "codecov",
 ]
-required = [
-    "appdirs",
-    "daiquiri",
-    "pygithub",
-    "colored",
-    "pluggy",
-    "repomate-plug>=0.4.1",
-]
+required = ["appdirs", "daiquiri", "pygithub", "colored", "repomate-plug>=0.4.1"]
 
 setup(
     name="repomate",


### PR DESCRIPTION
The cause for `pluggy` not being the version required in `repomate-plug` was that it was also listed as a requirement in `setup.py` here in Repomate. Repomate should not require `pluggy`, it should let `repomate-plug` handle that.

Fix #133 